### PR TITLE
feat: Update app to target Android 14 (API 34)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -47,7 +47,7 @@ android {
     defaultConfig {
         applicationId "app.carist"
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:8.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.15'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,29 +1,29 @@
 name: carist
 description: Carist
-version: 1.3.1+99726854
+version: 1.3.2+2025052210
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.4
-  google_fonts: ^4.0.3
-  http: ^0.13.4
-  firebase_core: ^2.7.0
-  firebase_auth: ^4.2.2
-  firebase_crashlytics: ^3.0.15
-  firebase_performance: ^0.9.0+14
-  cloud_firestore: ^4.4.3
+  google_fonts: ^6.2.1
+  http: ^1.0.0
+  firebase_core: ^3.4.0
+  firebase_auth: ^5.2.0
+  firebase_crashlytics: ^4.1.0
+  firebase_performance: ^0.10.0+5
+  cloud_firestore: ^5.4.0
   get: ^4.6.5
-  intl: ^0.18.0
+  intl: ^0.20.2
   transparent_image: ^2.0.0
-  screenshot: ^1.2.3
-  share_plus: ^6.3.1
+  screenshot: ^2.5.0
+  share_plus: ^10.0.0
   path_provider: ^2.0.10
-  package_info_plus: ^3.0.3
-  google_mobile_ads: ^2.3.0
+  package_info_plus: ^8.0.2
+  google_mobile_ads: ^5.2.0
   url_launcher: ^6.1.2
 
 dev_dependencies:


### PR DESCRIPTION
This commit includes the necessary changes to target Android API level 34, as per Google Play requirements.

Changes:
- Incremented app version to 1.3.2+2025052210.
- Updated google_fonts to ^6.2.1.
- Updated Dart SDK constraint to '>=3.0.0 <4.0.0'.
- Ran 'flutter pub upgrade --major-versions' to update other Flutter dependencies for better compatibility.
- Set compileSdkVersion and targetSdkVersion to 34 in android/app/build.gradle.
- Upgraded Android Gradle Plugin to 8.3.0 in android/build.gradle.
- Upgraded Gradle version to 8.4 in android/gradle/wrapper/gradle-wrapper.properties.

Note: You'll need to build the final app bundle in a local environment with the Android SDK correctly configured.